### PR TITLE
Fix relative import error in Flask app

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from flask import Flask, request, jsonify
 
-from .extractor import fetch_html, parse_products
+from extractor import fetch_html, parse_products
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 app = Flask(__name__, static_folder=str(BASE_DIR / "static"), static_url_path="")


### PR DESCRIPTION
## Summary
- adjust import path in `src/app.py`

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684b244f72508328af31c29b5298a8c5