### PR TITLE
Fix module import for Flask app

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 from flask import Flask, request, jsonify
 
-from src.extractor import fetch_html, parse_products
+# Import the extractor module from the same directory so that running
+# ``python src/app.py`` works without modifying ``PYTHONPATH``.
+from extractor import fetch_html, parse_products
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 app = Flask(__name__, static_folder=str(BASE_DIR / "static"), static_url_path="")


### PR DESCRIPTION
## Summary
- fix Flask app imports so running `python src/app.py` works

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_684b2bec82f483289b2639c3445eab89